### PR TITLE
feat: add automated sync for Kubex Automation Engine changelog

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,53 @@
+# GitHub Actions Workflows
+
+This directory contains automated workflows for maintaining the documentation.
+
+## Sync Kubex Automation Engine Changelog
+
+**File:** `workflows/sync-changelog.yml`
+
+### What it does
+Automatically syncs the Kubex Automation Engine CHANGELOG from the upstream helm-charts repository into the Release Notes documentation.
+
+### When it runs
+- **Automatically:** Daily at 2 AM UTC
+- **Manually:** Can be triggered from the Actions tab in GitHub
+
+### How it works
+1. Fetches the latest CHANGELOG.md from: `https://github.com/densify-dev/helm-charts/blob/master/charts/kubex-automation-engine/CHANGELOG.md`
+2. Converts the changelog format to Mintlify MDX accordion format
+3. Updates the Release Notes file: `docs/WebHelp_Densify_Cloud/Content/Release_Notes/New_Features_Cloud.mdx`
+4. Creates a pull request if changes are detected
+5. PR includes labels `documentation` and `automated` for easy filtering
+
+### Manual trigger
+To manually run the sync:
+1. Go to the **Actions** tab in GitHub
+2. Select **Sync Kubex Automation Engine Changelog** workflow
+3. Click **Run workflow**
+
+### Testing locally
+To test the sync script locally:
+
+```bash
+python3 .github/scripts/sync-changelog.py
+```
+
+### Customization
+To change the sync schedule, edit the cron expression in `sync-changelog.yml`:
+
+```yaml
+schedule:
+  - cron: '0 2 * * *'  # Daily at 2 AM UTC
+```
+
+Cron examples:
+- `0 2 * * *` - Daily at 2 AM UTC
+- `0 2 * * 1` - Weekly on Monday at 2 AM UTC
+- `0 */6 * * *` - Every 6 hours
+
+### Source URL
+The workflow syncs from this URL:
+https://github.com/densify-dev/helm-charts/blob/master/charts/kubex-automation-engine/CHANGELOG.md
+
+To change the source, update the `CHANGELOG_URL` variable in `scripts/sync-changelog.py`.

--- a/.github/scripts/sync-changelog.py
+++ b/.github/scripts/sync-changelog.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""
+Sync Kubex Automation Engine CHANGELOG from upstream repository.
+"""
+
+import re
+import requests
+from pathlib import Path
+
+# Configuration
+CHANGELOG_URL = "https://raw.githubusercontent.com/densify-dev/helm-charts/master/charts/kubex-automation-engine/CHANGELOG.md"
+RELEASE_NOTES_FILE = "docs/WebHelp_Densify_Cloud/Content/Release_Notes/New_Features_Cloud.mdx"
+
+# Markers to identify the section to replace
+START_MARKER = "## Kubex Automation Engine"
+LEGACY_MARKER = "### Legacy Kubex Automation Controller Release Notes"
+
+
+def fetch_changelog():
+    """Fetch the CHANGELOG from upstream repository."""
+    print(f"Fetching CHANGELOG from {CHANGELOG_URL}")
+    response = requests.get(CHANGELOG_URL, timeout=30)
+    response.raise_for_status()
+    return response.text
+
+
+def parse_changelog_entry(version_block):
+    """Parse a single version entry from the CHANGELOG."""
+    # Extract version and date from header like: ## [1.4.0] - 2026-06-11
+    header_match = re.match(r'^## \[([^\]]+)\] - (\d{4}-\d{2}-\d{2})', version_block)
+    if not header_match:
+        return None
+
+    version = header_match.group(1)
+    date_str = header_match.group(2)
+
+    # Convert date to readable format
+    from datetime import datetime
+    date_obj = datetime.strptime(date_str, '%Y-%m-%d')
+    formatted_date = date_obj.strftime('%B %d, %Y')
+
+    # Extract content (everything after the header line)
+    lines = version_block.split('\n')
+    content_lines = []
+
+    for line in lines[1:]:
+        stripped = line.strip()
+        if not stripped or stripped == '---':
+            continue
+
+        # Handle markdown h3 section headers - convert to bold text (no markdown headers allowed in accordions)
+        if stripped.startswith('### Added'):
+            # Add blank line before new section (except first)
+            if content_lines:
+                content_lines.append('')
+            content_lines.append('**Added:**')
+        elif stripped.startswith('### Changed'):
+            if content_lines:
+                content_lines.append('')
+            content_lines.append('**Changed:**')
+        elif stripped.startswith('### Fixed'):
+            if content_lines:
+                content_lines.append('')
+            content_lines.append('**Fixed:**')
+        else:
+            # Regular content line - keep list items as-is
+            content_lines.append(stripped)
+
+    # Join with proper indentation - preserve empty lines for spacing
+    formatted_lines = []
+    for line in content_lines:
+        formatted_lines.append(line)
+
+    content = '\n    '.join(formatted_lines).strip()
+
+    # Create a title for the accordion
+    title_parts = []
+    if '**Added:**' in content:
+        # Extract first Added item as title
+        added_match = re.search(r'\*\*Added:\*\* ([^\n]+)', content)
+        if added_match:
+            title_parts.append(added_match.group(1))
+
+    if not title_parts:
+        title_parts.append("Updates and Improvements")
+
+    title = title_parts[0][:60]  # Truncate if too long
+
+    return {
+        'version': version,
+        'date': formatted_date,
+        'title': title,
+        'content': content
+    }
+
+
+def convert_changelog_to_mdx(changelog_text):
+    """Convert CHANGELOG markdown to Mintlify MDX accordion format."""
+    # Split into version blocks
+    version_blocks = re.split(r'^## ', changelog_text, flags=re.MULTILINE)[1:]
+
+    mdx_sections = []
+
+    for block in version_blocks:
+        # Add back the ## that was removed by split
+        block = '## ' + block
+        entry = parse_changelog_entry(block)
+
+        if entry:
+            accordion = f'''<Accordion title="{entry['version']} - {entry['date']}">
+  <Accordion title="{entry['title']}">
+    {entry['content']}
+  </Accordion>
+</Accordion>'''
+            mdx_sections.append(accordion)
+
+    return '\n\n'.join(mdx_sections)
+
+
+def update_release_notes(new_content):
+    """Update the release notes file with new CHANGELOG content."""
+    file_path = Path(RELEASE_NOTES_FILE)
+
+    if not file_path.exists():
+        print(f"Error: {RELEASE_NOTES_FILE} not found")
+        return False
+
+    # Read current content
+    current_content = file_path.read_text(encoding='utf-8')
+
+    # Find the section to replace
+    start_idx = current_content.find(START_MARKER)
+    legacy_idx = current_content.find(LEGACY_MARKER, start_idx)
+
+    if start_idx == -1 or legacy_idx == -1:
+        print("Error: Could not find markers in release notes file")
+        return False
+
+    # Build new content - just the header and changelog, no note
+    header = '''## Kubex Automation Engine
+
+'''
+
+    new_section = header + new_content + '\n\n'
+
+    # Replace the section
+    before = current_content[:start_idx]
+    after = current_content[legacy_idx:]
+
+    # Add the deprecation note to the legacy section header
+    legacy_with_note = '''### Legacy Kubex Automation Controller Release Notes
+
+<Note>
+The Kubex Automation Controller has been deprecated and replaced by the Kubex Automation Engine.
+</Note>
+
+'''
+
+    # Replace just the legacy header line with header + note
+    after = after.replace(LEGACY_MARKER + '\n\n', legacy_with_note)
+
+    updated_content = before + new_section + after
+
+    # Write back
+    file_path.write_text(updated_content, encoding='utf-8')
+    print(f"Updated {RELEASE_NOTES_FILE}")
+    return True
+
+
+def main():
+    """Main execution."""
+    try:
+        # Fetch changelog
+        changelog = fetch_changelog()
+
+        # Convert to MDX format
+        mdx_content = convert_changelog_to_mdx(changelog)
+
+        # Update release notes file
+        if update_release_notes(mdx_content):
+            print("Sync completed successfully")
+            return 0
+        else:
+            print("Sync failed")
+            return 1
+
+    except Exception as e:
+        print(f"Error: {e}")
+        import traceback
+        traceback.print_exc()
+        return 1
+
+
+if __name__ == '__main__':
+    exit(main())

--- a/.github/workflows/sync-changelog.yml
+++ b/.github/workflows/sync-changelog.yml
@@ -1,0 +1,62 @@
+name: Sync Kubex Automation Engine Changelog
+
+on:
+  schedule:
+    # Run daily at 2 AM UTC
+    - cron: '0 2 * * *'
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  sync-changelog:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          pip install requests
+
+      - name: Fetch and sync CHANGELOG
+        id: sync
+        run: |
+          python .github/scripts/sync-changelog.py
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "No changes detected"
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "Changes detected"
+          fi
+
+      - name: Create Pull Request
+        if: steps.changes.outputs.has_changes == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: 'docs: sync Kubex Automation Engine changelog'
+          title: 'Update Kubex Automation Engine Release Notes'
+          body: |
+            This PR automatically syncs the Kubex Automation Engine changelog from the upstream repository.
+
+            Source: https://github.com/densify-dev/helm-charts/blob/master/charts/kubex-automation-engine/CHANGELOG.md
+
+            Please review the changes and merge if everything looks correct.
+          branch: sync-changelog-${{ github.run_number }}
+          delete-branch: true
+          labels: documentation, automated

--- a/docs/WebHelp_Densify_Cloud/Content/Release_Notes/New_Features_Cloud.mdx
+++ b/docs/WebHelp_Densify_Cloud/Content/Release_Notes/New_Features_Cloud.mdx
@@ -1550,13 +1550,157 @@ When deploying the Container Data Forwarder ensure that the same version is depl
 
 ## Kubex Automation Engine
 
-<Note>
-The Kubex Automation Controller has been deprecated and replaced by the Kubex Automation Engine. All release notes for the Kubex Automation Engine are now maintained on GitHub. See the [Kubex Automation Engine CHANGELOG](https://github.com/densify-dev/helm-charts/blob/master/charts/kubex-automation-engine/CHANGELOG.md) for the latest updates.
-</Note>
+<Accordion title="1.4.0 - June 11, 2026">
+  <Accordion title="Updates and Improvements">
+    **Added:**
+    - Initial formal release of the integration with the KAI scheduler for rightsizing fractional GPUs
+    
+    **Changed:**
+    - KAI documentation, examples, and release notes were updated for the `v1.4.0` release
+  </Accordion>
+</Accordion>
 
-This section lists historical features and updates to the Kubex Automation Controller (now deprecated). For current release information, refer to the [Kubex Automation Engine](https://github.com/densify-dev/helm-charts/tree/master/charts/kubex-automation-engine) repository.
+<Accordion title="1.3.1 - June 09, 2026">
+  <Accordion title="Updates and Improvements">
+    **Changed:**
+    - Default policy evaluation now gives `RollbackPolicy` and `ClusterRollbackPolicy` the highest precedence.
+  </Accordion>
+</Accordion>
+
+<Accordion title="1.3.0 - June 04, 2026">
+  <Accordion title="Updates and Improvements">
+    **Added:**
+    - Introduced Rollback automation so clusters can now use the rollback state machine in live environments.
+    
+    **Changed:**
+    - Rollback owner/runtime handling and e2e fixtures were updated to support the new rollback flow.
+    
+    **Fixed:**
+    - Live rollback e2e instability caused by synthetic state seeding.
+  </Accordion>
+</Accordion>
+
+<Accordion title="1.2.0 - June 02, 2026">
+  <Accordion title="Updates and Improvements">
+    **Added:**
+    - Webhook/client behavior improvements that make policy admission and reconciliation more resilient.
+    
+    **Changed:**
+    - Webhook reconciliation now uses informers/client behavior tuned for more reliable event handling.
+    - GPU-related e2e and policy behavior was refined for stability and consistency.
+    - Chart/docs content was updated to reflect the current release flow and user-facing guidance.
+    
+    **Fixed:**
+    - Webhook error handling paths that could surface avoidable failures.
+    - Miscellaneous release-blocking regressions from the beta cycle.
+  </Accordion>
+</Accordion>
+
+<Accordion title="1.1.0 - May 26, 2026">
+  <Accordion title="Updates and Improvements">
+    **Added:**
+    - PodAffinityPolicy automation for supported workload types, including preferred node placement rules
+    - StrimziPodSet workload support for automating Strimzi-managed Kafka pods
+    - Prometheus scraping support for controller metrics with a chart-managed metrics service and optional ServiceMonitor
+    - Added experimental support for GPU sharing using the KAI scheduler
+    
+    **Changed:**
+    - GPU proactive policies can use `gpuOverallOptimal` recommendations from KAI for overall GPU optimization
+    - Resize summaries now show when recommendations were clamped to configured resource bounds
+  </Accordion>
+</Accordion>
+
+<Accordion title="1.0.0 - May 07, 2026">
+  <Accordion title="Updates and Improvements">
+    **Changed:**
+    - No customer-facing changes in this release.
+  </Accordion>
+</Accordion>
+
+<Accordion title="0.4.0 - May 05, 2026">
+  <Accordion title="Updates and Improvements">
+    **Added:**
+    - Namespace-level pause controls using the `rightsizing.kubex.ai/pause-until` annotation so automation can be paused across an entire namespace without annotating each pod individually
+  </Accordion>
+</Accordion>
+
+<Accordion title="0.3.0 - May 01, 2026">
+  <Accordion title="Updates and Improvements">
+    **Added:**
+    - Time-based automation scheduling with configurable windows including all-day support, overnight windows, and 24:00 explicit end time
+    - Policy snapshot uploads to Kubex gateway via automation-gateway with configurable intervals
+    
+    **Changed:**
+    - VPA resizing now requires active VPA recommendation conditions before allowing resize plans to prevent premature operations
+    
+    **Fixed:**
+    - Stale owner recommendation cleanup flow for missing automation strategies
+    - Overlapping exclusion window handling by jumping to the latest end time
+    - Startup policy rescan now triggers automatically after readiness opens
+  </Accordion>
+</Accordion>
+
+<Accordion title="0.2.1 - April 01, 2026">
+  <Accordion title="Updates and Improvements">
+    **Added:**
+    - Configurable webhook probe pod settings via GlobalConfiguration including image selection
+    - ImagePullSecrets and securityContext support for enhanced security configuration
+    - GlobalConfiguration singleton enforcement via validating webhook to prevent multiple instances
+    
+    **Fixed:**
+    - Case-insensitive HPA kind detection to match HPA targets regardless of casing
+    - Guaranteed QoS resize plan calculation to correctly normalize requests and limits
+  </Accordion>
+</Accordion>
+
+<Accordion title="0.2.0 - March 01, 2026">
+  <Accordion title="Updates and Improvements">
+    **Added:**
+    - Guaranteed QoS support with `retainGuaranteedQOS` flag to enforce requests==limits constraint
+    
+    **Fixed:**
+    - Webhook retry handling to properly manage too-many-requests scenarios
+    - Resize method preservation in retry scenarios to maintain consistency across retries
+    - Workload-to-policy namespace matching to ensure correct policy application
+  </Accordion>
+</Accordion>
+
+<Accordion title="0.1.3 - February 01, 2026">
+  <Accordion title="Updates and Improvements">
+    **Added:**
+    - Per-container enablement bounds to set different resource floor and ceiling limits for individual containers within a pod
+    
+    **Fixed:**
+    - Webhook validation for inherited automation strategy bounds to ensure proper constraint enforcement
+  </Accordion>
+</Accordion>
+
+<Accordion title="0.1.2 - January 15, 2026">
+  <Accordion title="Updates and Improvements">
+    **Added:**
+    - Webhook validation for policy automation strategy references to ensure referential integrity
+    - Protection against deleting automation strategies that are actively referenced by policies
+    
+    **Fixed:**
+    - ENABLE_WEBHOOKS flag parsing to correctly interpret as boolean value
+  </Accordion>
+</Accordion>
+
+<Accordion title="0.1.1 - January 01, 2026">
+  <Accordion title="Updates and Improvements">
+    **Changed:**
+    - Rebranded from previous name to Kubex
+    
+    **Fixed:**
+    - Workload-to-policy namespace matching to ensure policies are applied to correct workloads
+  </Accordion>
+</Accordion>
 
 ### Legacy Kubex Automation Controller Release Notes
+
+<Note>
+The Kubex Automation Controller has been deprecated and replaced by the Kubex Automation Engine.
+</Note>
 
 The Kubex Automation Controller automatically implemented Kubex's optimization recommendations for Kubernetes workloads.
 


### PR DESCRIPTION
Add GitHub Actions workflow to automatically sync the Kubex Automation Engine CHANGELOG from the upstream helm-charts repository.

Changes:
- Daily workflow runs at 2 AM UTC to fetch latest CHANGELOG
- Converts changelog to Mintlify MDX accordion format
- Updates release notes with proper formatting and spacing
- Creates PR automatically when changes detected
- Manual trigger available via GitHub Actions UI
- Moved deprecation notice to Legacy section

The workflow fetches content from:
https://github.com/densify-dev/helm-charts/blob/master/charts/kubex-automation-engine/CHANGELOG.md