### PR TITLE
fix: update changelog sync script to use new release notes file

### DIFF
--- a/.github/scripts/sync-changelog.py
+++ b/.github/scripts/sync-changelog.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 # Configuration
 CHANGELOG_URL = "https://raw.githubusercontent.com/densify-dev/helm-charts/master/charts/kubex-automation-engine/CHANGELOG.md"
-RELEASE_NOTES_FILE = "docs/WebHelp_Densify_Cloud/Content/Release_Notes/New_Features_Cloud.mdx"
+RELEASE_NOTES_FILE = "docs/WebHelp_Densify_Cloud/Content/Release_Notes/release_notes_k8s_automation_engine.mdx"
 
 # Markers to identify the section to replace
 START_MARKER = "## Kubex Automation Engine"


### PR DESCRIPTION
Updated sync-changelog.py to target the new release_notes_k8s_automation_engine.mdx file instead of New_Features_Cloud.mdx, following the documentation restructuring that separated Container Data Collector and Kubex Automation Engine release notes into separate files.